### PR TITLE
Improve README instructions for Windows venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,26 @@ cd inventurwebseite
 
 2. Virtuelles Environment anlegen und Abhängigkeiten installieren
 
+Auf Linux/macOS:
+
 ```bash
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+Auf Windows PowerShell:
+
+```powershell
+python -m venv venv
+.\venv\Scripts\Activate
+pip install -r requirements.txt
+```
+
+Falls Sie Git Bash auf Windows verwenden, aktivieren Sie die Umgebung mit:
+
+```bash
+source venv/Scripts/activate
 ```
 
 3. Datenbank migrieren und Server starten


### PR DESCRIPTION
## Summary
- add detailed instructions for activating the virtual environment on Linux/macOS, Windows PowerShell and Git Bash

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6866bc4dd3f88323aa93de224b3e3b61