### PR TITLE
Add homepage view

### DIFF
--- a/inventurprojekt/inventurprojekt/urls.py
+++ b/inventurprojekt/inventurprojekt/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.views.generic import TemplateView
 
 urlpatterns = [
+    path('', TemplateView.as_view(template_name='base.html'), name='home'),
     path('admin/', admin.site.urls),
     path('api/', include('inventory.urls')),
 ]


### PR DESCRIPTION
## Summary
- add a homepage route that renders `base.html` so `/` is no longer 404

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r ../requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866bc83692c8323858300d67c42ab8d