### PR TITLE
Run migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,8 @@ python manage.py migrate
 python manage.py runserver 0.0.0.0:8000
 ```
 
+Das Skript `manage.py` versucht beim Start des Servers automatisch, ausstehende
+Migrationen auszuführen. Sollten Sie dennoch Fehlermeldungen wie
+"no such table" erhalten, führen Sie `python manage.py migrate` manuell aus.
+
 4. Zugriff von außen (z. B. über Port-Forwarding oder DynDNS) nur für die eigene IP freigeben. Dies kann auf Router-Ebene oder per Firewall-Regel erfolgen.

--- a/inventurprojekt/manage.py
+++ b/inventurprojekt/manage.py
@@ -4,5 +4,12 @@ import sys
 
 if __name__ == '__main__':
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inventurprojekt.settings')
-    from django.core.management import execute_from_command_line
+    from django.core.management import execute_from_command_line, call_command
+
+    if 'runserver' in sys.argv:
+        try:
+            call_command('migrate', interactive=False)
+        except Exception as exc:
+            print(f'Could not run migrations: {exc}')
+
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
## Summary
- run migrations automatically when starting the dev server
- document auto-migrate behavior in README

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6866c4eb2e988323b22a5c5dd028c1c4