### PR TITLE
Show calendar page

### DIFF
--- a/inventurprojekt/static/js/calendar.js
+++ b/inventurprojekt/static/js/calendar.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const now = new Date();
+    renderCalendar(now.getFullYear(), now.getMonth());
+});
+
+function renderCalendar(year, month) {
+    const calendarDiv = document.getElementById('calendar');
+    if (!calendarDiv) return;
+
+    calendarDiv.innerHTML = '';
+    const table = document.createElement('table');
+    table.classList.add('table');
+
+    // Header with month and year
+    const monthNames = ['Januar', 'Februar', 'M\u00e4rz', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'];
+    const headerRow = document.createElement('tr');
+    const headerCell = document.createElement('th');
+    headerCell.colSpan = 7;
+    headerCell.textContent = monthNames[month] + ' ' + year;
+    headerRow.appendChild(headerCell);
+    table.appendChild(headerRow);
+
+    // Day names
+    const dayNames = ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'];
+    const daysRow = document.createElement('tr');
+    dayNames.forEach(name => {
+        const th = document.createElement('th');
+        th.textContent = name;
+        daysRow.appendChild(th);
+    });
+    table.appendChild(daysRow);
+
+    const firstDay = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    let row = document.createElement('tr');
+
+    // Empty cells until first day
+    for (let i = 0; i < firstDay; i++) {
+        row.appendChild(document.createElement('td'));
+    }
+
+    for (let day = 1; day <= daysInMonth; day++) {
+        if ((firstDay + day - 1) % 7 === 0 && day > 1) {
+            table.appendChild(row);
+            row = document.createElement('tr');
+        }
+        const td = document.createElement('td');
+        td.textContent = day;
+        row.appendChild(td);
+    }
+
+    // Fill remaining cells
+    while (row.children.length < 7) {
+        row.appendChild(document.createElement('td'));
+    }
+    table.appendChild(row);
+    calendarDiv.appendChild(table);
+}

--- a/inventurprojekt/templates/calendar.html
+++ b/inventurprojekt/templates/calendar.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% block title %}Kalender{% endblock %}
 {% block content %}
-<h1>Kalender</h1>
-<p>Kalender-Übersicht.</p>
+<h1 class="mb-4">Kalender</h1>
+<div id="calendar"></div>
+{% endblock %}
+{% block scripts %}
+<script src="/static/js/calendar.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a small calendar.js renderer
- render a calendar table on the Kalender page

## Testing
- `python -m compileall -q inventurprojekt`

------
https://chatgpt.com/codex/tasks/task_e_6866cd966ed08323ad2aff71f1770eac