### PR TITLE
Add product creation capability

### DIFF
--- a/inventurprojekt/inventory/admin.py
+++ b/inventurprojekt/inventory/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from .models import Item, Order
+from .models import Item, Order, Product
 
 admin.site.register(Item)
 admin.site.register(Order)
+admin.site.register(Product)

--- a/inventurprojekt/inventory/forms.py
+++ b/inventurprojekt/inventory/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Order
+from .models import Order, Product
 
 
 class OrderForm(forms.ModelForm):
@@ -8,3 +8,9 @@ class OrderForm(forms.ModelForm):
     class Meta:
         model = Order
         fields = ['name', 'description', 'product', 'due_date']
+
+
+class ProductForm(forms.ModelForm):
+    class Meta:
+        model = Product
+        fields = ['name', 'purchase_link', 'is_apple', 'photo']

--- a/inventurprojekt/inventory/migrations/0003_product.py
+++ b/inventurprojekt/inventory/migrations/0003_product.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0002_order'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Product',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+                ('purchase_link', models.URLField(blank=True)),
+                ('is_apple', models.BooleanField(default=False)),
+                ('photo', models.ImageField(blank=True, null=True, upload_to='product_photos/')),
+            ],
+        ),
+    ]

--- a/inventurprojekt/inventory/models.py
+++ b/inventurprojekt/inventory/models.py
@@ -1,5 +1,15 @@
 from django.db import models
 
+
+class Product(models.Model):
+    name = models.CharField(max_length=255)
+    purchase_link = models.URLField(blank=True)
+    is_apple = models.BooleanField(default=False)
+    photo = models.ImageField(upload_to='product_photos/', blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
 class Item(models.Model):
     name = models.CharField(max_length=255)
     quantity = models.IntegerField(default=0)

--- a/inventurprojekt/inventory/views.py
+++ b/inventurprojekt/inventory/views.py
@@ -1,9 +1,9 @@
 from rest_framework import generics
 from django.views.generic import ListView, CreateView, TemplateView
 from django.urls import reverse_lazy
-from .models import Item, Order
+from .models import Item, Order, Product
 from .serializers import ItemSerializer, OrderSerializer
-from .forms import OrderForm
+from .forms import OrderForm, ProductForm
 
 class ItemListCreateView(generics.ListCreateAPIView):
     queryset = Item.objects.all()
@@ -43,3 +43,15 @@ class CalendarView(TemplateView):
         context = super().get_context_data(**kwargs)
         context['orders'] = Order.objects.all().order_by('due_date')
         return context
+
+
+class ProductListView(ListView):
+    model = Product
+    template_name = 'products.html'
+
+
+class ProductCreateView(CreateView):
+    model = Product
+    form_class = ProductForm
+    template_name = 'product_form.html'
+    success_url = reverse_lazy('products')

--- a/inventurprojekt/inventurprojekt/settings.py
+++ b/inventurprojekt/inventurprojekt/settings.py
@@ -63,6 +63,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / 'static']
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGIN_REDIRECT_URL = '/'

--- a/inventurprojekt/inventurprojekt/urls.py
+++ b/inventurprojekt/inventurprojekt/urls.py
@@ -3,16 +3,19 @@ from django.urls import path, include
 from django.views.generic import TemplateView
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import views as auth_views
-from inventory.views import OrderListView, OrderCreateView, CalendarView
+from django.conf import settings
+from django.conf.urls.static import static
+from inventory.views import OrderListView, OrderCreateView, CalendarView, ProductListView, ProductCreateView
 
 urlpatterns = [
     path('', TemplateView.as_view(template_name='inventory.html'), name='home'),
     path('auftraege/', OrderListView.as_view(), name='orders'),
     path('auftraege/neu/', OrderCreateView.as_view(), name='order-create'),
     path('kalender/', CalendarView.as_view(), name='calendar'),
-    path('produkte/', TemplateView.as_view(template_name='products.html'), name='products'),
+    path('produkte/', ProductListView.as_view(), name='products'),
+    path('produkte/neu/', ProductCreateView.as_view(), name='product-create'),
     path('admin/', admin.site.urls),
     path('api/', include('inventory.urls')),
     path('accounts/login/', auth_views.LoginView.as_view(), name='login'),
     path('accounts/logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/inventurprojekt/templates/product_form.html
+++ b/inventurprojekt/templates/product_form.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Produkt hinzufügen{% endblock %}
+{% block content %}
+<h1 class="mb-3">Produkt hinzufügen</h1>
+<form method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="btn btn-primary">Speichern</button>
+</form>
+{% endblock %}

--- a/inventurprojekt/templates/products.html
+++ b/inventurprojekt/templates/products.html
@@ -1,6 +1,34 @@
 {% extends 'base.html' %}
 {% block title %}Produkte{% endblock %}
 {% block content %}
-<h1>Produkte</h1>
-<p>Liste der Produkte.</p>
+<h1 class="mb-3">Produkte</h1>
+<a href="{% url 'product-create' %}" class="btn btn-primary mb-3">Produkt hinzufügen</a>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Link</th>
+            <th>Apple Produkt</th>
+            <th>Foto</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for product in object_list %}
+        <tr>
+            <td>{{ product.name }}</td>
+            <td><a href="{{ product.purchase_link }}">{{ product.purchase_link }}</a></td>
+            <td>{% if product.is_apple %}Ja{% else %}Nein{% endif %}</td>
+            <td>
+                {% if product.photo %}
+                    <img src="{{ product.photo.url }}" alt="{{ product.name }}" width="50">
+                {% else %}
+                    -
+                {% endif %}
+            </td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4">Keine Produkte vorhanden.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=4.0,<5.0
 djangorestframework
+Pillow


### PR DESCRIPTION
## Summary
- support new `Product` model with fields for link, Apple checkmark and photo
- implement product form, list view and creation page
- hook into URLs and templates
- enable image uploads via media settings
- register model in admin
- add Pillow to requirements
- include migration for product model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686a93e4e5e483239201365f47c7979c