### PR TITLE
Implement warranty calendar entry

### DIFF
--- a/inventurprojekt/inventory/apps.py
+++ b/inventurprojekt/inventory/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 class InventoryConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'inventory'
+
+    def ready(self):
+        from . import signals

--- a/inventurprojekt/inventory/migrations/0003_item_brand_purchase_date.py
+++ b/inventurprojekt/inventory/migrations/0003_item_brand_purchase_date.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('inventory', '0002_order'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='item',
+            name='brand',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='item',
+            name='purchase_date',
+            field=models.DateField(auto_now_add=True, default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+    ]

--- a/inventurprojekt/inventory/models.py
+++ b/inventurprojekt/inventory/models.py
@@ -4,6 +4,8 @@ class Item(models.Model):
     name = models.CharField(max_length=255)
     quantity = models.IntegerField(default=0)
     location = models.CharField(max_length=255)
+    brand = models.CharField(max_length=255, blank=True)
+    purchase_date = models.DateField(auto_now_add=True)
 
     def __str__(self):
         return self.name

--- a/inventurprojekt/inventory/serializers.py
+++ b/inventurprojekt/inventory/serializers.py
@@ -4,7 +4,8 @@ from .models import Item, Order
 class ItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = Item
-        fields = ['id', 'name', 'quantity', 'location']
+        fields = ['id', 'name', 'quantity', 'location', 'brand', 'purchase_date']
+        read_only_fields = ['purchase_date']
 
 
 class OrderSerializer(serializers.ModelSerializer):

--- a/inventurprojekt/inventory/signals.py
+++ b/inventurprojekt/inventory/signals.py
@@ -1,0 +1,16 @@
+from datetime import timedelta
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from .models import Item, Order
+
+@receiver(post_save, sender=Item)
+def create_warranty_order(sender, instance, created, **kwargs):
+    if not created:
+        return
+    warranty_years = 1 if instance.brand.lower() == 'apple' else 2
+    due_date = instance.purchase_date + timedelta(days=365 * warranty_years)
+    Order.objects.create(
+        name=f"Garantieablauf: {instance.name}",
+        product=instance,
+        due_date=due_date,
+    )


### PR DESCRIPTION
## Summary
- add brand and purchase date fields to items
- create warranty reminder automatically when an item is created
- expose new fields via API
- hook signals in app config
- provide migration for the new fields

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 manage.py makemigrations inventory` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686a9427ad888323be897d41684f4f60