### PR TITLE
Set calendar as homepage

### DIFF
--- a/inventurprojekt/inventurprojekt/urls.py
+++ b/inventurprojekt/inventurprojekt/urls.py
@@ -6,7 +6,8 @@ from django.contrib.auth import views as auth_views
 from inventory.views import OrderListView, OrderCreateView, CalendarView
 
 urlpatterns = [
-    path('', TemplateView.as_view(template_name='inventory.html'), name='home'),
+    path('', CalendarView.as_view(), name='home'),
+    path('inventar/', TemplateView.as_view(template_name='inventory.html'), name='inventory'),
     path('auftraege/', OrderListView.as_view(), name='orders'),
     path('auftraege/neu/', OrderCreateView.as_view(), name='order-create'),
     path('kalender/', CalendarView.as_view(), name='calendar'),

--- a/inventurprojekt/templates/base.html
+++ b/inventurprojekt/templates/base.html
@@ -9,10 +9,11 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/">Home</a>
+            <a class="navbar-brand" href="{% url 'home' %}">Kalender</a>
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item"><a class="nav-link" href="{% url 'orders' %}">Aufträge</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{% url 'inventory' %}">Inventar</a></li>
                     <li class="nav-item"><a class="nav-link" href="{% url 'calendar' %}">Kalender</a></li>
                     <li class="nav-item"><a class="nav-link" href="{% url 'products' %}">Produkte</a></li>
                 </ul>
@@ -21,22 +22,6 @@
     </nav>
     <div class="container">
         {% block content %}{% endblock %}
-    <nav class="navbar navbar-light bg-light mb-4">
-        <div class="container-fluid">
-            <span class="navbar-brand mb-0 h1">Inventar</span>
-        </div>
-    </nav>
-    <div class="container mb-4">
-        <table class="table" id="items-table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Menge</th>
-                    <th>Ort</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
     </div>
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
## Summary
- set calendar view as the homepage
- keep inventory available under `/inventar/`
- clean up base template and adjust navigation

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686a9486e9d883238a1bfd9301f61368